### PR TITLE
Properly declare the member functions

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -119,7 +119,7 @@ export default {
   },
 
   // activate linter
-  activate: () => {
+  activate() {
     require('atom-package-deps').install('linter-ansible-linting');
 
     const helpers = require("atom-linter");
@@ -139,7 +139,7 @@ export default {
     });
   },
 
-  provideLinter: () => {
+  provideLinter() {
     return {
       name: 'Ansible-Lint',
       grammarScopes: ['source.ansible'],


### PR DESCRIPTION
Function declaration using an arrow function in the global scope is invalid, and the cleaner transpilation in Atom v1.16.0 breaks on this method.

See https://github.com/atom/atom/pull/13823#issuecomment-286985411 for details.