### PR TITLE
Fix path reference and use a single global helpers variable

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -184,7 +184,7 @@ export default {
                 location: {
                   // ansible-lint plus atom-linter combined now lose pathing info for this kind of parsing
                   // prepend dir to file
-                  file: dir + path.delimiter + lint_matches[1],
+                  file: dir + path.sep + lint_matches[1],
                   position: [[Number.parseInt(lint_matches[2]) - 1, 0], [Number.parseInt(lint_matches[2]) - 1, 1]],
                 },
               });

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,19 @@
 'use babel';
 
+// eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
+import path from 'path';
+
+const packageName = 'linter-ansible-linting'
+
+// Dependencies
+let helpers;
+
+const loadDeps = () => {
+  if (!helpers) {
+    helpers = require('atom-linter');
+  }
+};
+
 export default {
   config: {
     ansibleLintExecutablePath: {
@@ -65,10 +79,12 @@ export default {
 
   // activate linter
   activate() {
-    const helpers = require('atom-linter');
+
+    // Load the dependencies if they aren't already
+    loadDeps();
 
     // check for ansible-lint >= minimum version
-    helpers.exec(atom.config.get('linter-ansible-linting.ansibleLintExecutablePath'), ['-T']).then(output => {
+    helpers.exec(atom.config.get(packageName + '.ansibleLintExecutablePath'), ['-T']).then(output => {
       if (!(/repeatability/.exec(output))) {
         atom.notifications.addWarning(
           'ansible-lint < 3.5 is unsupported. Backwards compatibility should exist, but is not guaranteed.',
@@ -89,15 +105,17 @@ export default {
       lintsOnChange: false,
       lint: (activeEditor) => {
         // setup variables
-        const helpers = require('atom-linter');
         const lint_regex = /(.*):(\d+):\s\[E\d{3}\]\s(.*)/;
         const file = activeEditor.getPath();
-        const dir = require('path').dirname(file);
+        const dir = path.dirname(file);
         const correct_file = new RegExp(file);
 
+        // Load the dependencies if they aren't already
+        loadDeps();
+
         // bail out if this is on the blacklist
-        if (atom.config.get('linter-ansible-linting.blacklist') !== '') {
-          blacklist = new RegExp(atom.config.get('linter-ansible-linting.blacklist'))
+        if (atom.config.get(packageName + '.blacklist') !== '') {
+          blacklist = new RegExp(atom.config.get(packageName + '.blacklist'))
           if (blacklist.exec(file))
             return [];
         }
@@ -106,11 +124,11 @@ export default {
         var args = ['-p', '--nocolor'];
 
         // add parseable severity flag if requested
-        if (atom.config.get('linter-ansible-linting.displaySeverity'))
+        if (atom.config.get(packageName + '.displaySeverity'))
           args.push('--parseable-severity');
 
         // use config file if specified
-        if (atom.config.get('linter-ansible-linting.useProjectConfig')) {
+        if (atom.config.get(packageName + '.useProjectConfig')) {
           // cannot cwd in project path and then add file relative path to args because ansible relies on pathing relative to directory execution for includes
           const project_path = atom.project.relativizePath(file)[0];
 
@@ -119,22 +137,22 @@ export default {
         }
         else {
           // skip checks that user has opted to skip
-          if (atom.config.get('linter-ansible-linting.ruleSkips') != '')
-            args.push(...['-x', atom.config.get('linter-ansible-linting.ruleSkips')])
+          if (atom.config.get(packageName + '.ruleSkips') != '')
+            args.push(...['-x', atom.config.get(packageName + '.ruleSkips')])
 
           // add additional rules directories
-          if (atom.config.get('linter-ansible-linting.rulesDirs')[0] !== '') {
-            if (atom.config.get('linter-ansible-linting.rulesDirDefault'))
+          if (atom.config.get(packageName + '.rulesDirs')[0] !== '') {
+            if (atom.config.get(packageName + '.rulesDirDefault'))
               args.push('-R')
 
-            for (i = 0; i < atom.config.get('linter-ansible-linting.rulesDirs').length; i++)
-              args.push(...['-r', atom.config.get('linter-ansible-linting.rulesDirs')[i]]);
+            for (i = 0; i < atom.config.get(packageName + '.rulesDirs').length; i++)
+              args.push(...['-r', atom.config.get(packageName + '.rulesDirs')[i]]);
           }
 
           // exclude certain directories from checks
-          if (atom.config.get('linter-ansible-linting.excludeDirs')[0] != '')
-            for (i = 0; i < atom.config.get('linter-ansible-linting.excludeDirs').length; i++)
-              args.push(...['--exclude', atom.config.get('linter-ansible-linting.excludeDirs')[i]]);
+          if (atom.config.get(packageName + '.excludeDirs')[0] != '')
+            for (i = 0; i < atom.config.get(packageName + '.excludeDirs').length; i++)
+              args.push(...['--exclude', atom.config.get(packageName + '.excludeDirs')[i]]);
         }
 
         // add file to check
@@ -142,8 +160,7 @@ export default {
 
         // initialize variable for linter return here for either linter output or errors
         var toReturn = [];
-
-        return helpers.exec(atom.config.get('linter-ansible-linting.ansibleLintExecutablePath'), args, {cwd: dir, ignoreExitCode: true, timeout: atom.config.get('linter-ansible-linting.timeout') * 1000}).then(output => {
+        return helpers.exec(atom.config.get(packageName + '.ansibleLintExecutablePath'), args, {cwd: dir, ignoreExitCode: true, timeout: atom.config.get(packageName + '.timeout') * 1000}).then(output => {
           output.split(/\r?\n/).forEach((line) => {
             const lint_matches = lint_regex.exec(line);
             const correct_file_matches = correct_file.exec(line);
@@ -167,7 +184,7 @@ export default {
                 location: {
                   // ansible-lint plus atom-linter combined now lose pathing info for this kind of parsing
                   // prepend dir to file
-                  file: dir + lint_matches[1],
+                  file: dir + path.delimiter + lint_matches[1],
                   position: [[Number.parseInt(lint_matches[2]) - 1, 0], [Number.parseInt(lint_matches[2]) - 1, 1]],
                 },
               });


### PR DESCRIPTION
I had an issue where the path to the file was wrong and just needed a path.delimiter character.

In trying to fix this I created my own package name so turned that into a variable and also copied some dependency loading functionality from another linter.