### PR TITLE
support new ansible-lint version schema

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -76,7 +76,7 @@ export default {
     // check ansible-lint version
     helpers.exec(atom.config.get('linter-ansible-linting.ansibleLintExecutablePath'), ['--version']).then(output => {
       // check if ansible-lint >= 5
-      if (/^ansible-lint [0-4]\./.exec(output)) {
+      if (/^ansible-lint (?!([5-9]|\d{2,}))\./.exec(output)) {
         atom.notifications.addWarning(
           'ansible-lint < 5.0 is unsupported. Backwards compatibility should exist, but is not guaranteed.',
           {


### PR DESCRIPTION
https://github.com/ansible/ansible-lint/releases

prevents start up warning "ansible-lint < 5.0 is unsupported. Backwards compatibility should exist, but is not guaranteed. Please upgrade your version of ansible-lint to >= 5.0" with ansible-lint v24+